### PR TITLE
Feature/telnet logging to logfiles

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -109,6 +109,8 @@ cp -v rtlsdr-ogn.conf /etc/rtlsdr-ogn.conf
 update-rc.d rtlsdr-ogn defaults
 cd -
 
+# step 9: install logrotate for ogn logfiles
+cp -v /home/pi/logrotate /etc/logrotate.d/rtlsdr-ogn
 
 
 # ------  Phase TWO: install additional tooling and configuration

--- a/logrotate
+++ b/logrotate
@@ -1,0 +1,9 @@
+/var/log/rtlsdr-ogn/*.log {
+    rotate 3
+    size=10M
+    daily
+    missingok
+    notifempty
+    compress
+    copytruncate
+}

--- a/rtlsdr-ogn
+++ b/rtlsdr-ogn
@@ -119,7 +119,7 @@ launch () {
     pidfile=/tmp/procServ-$PORT.pid
     rm -f $pidfile
 #    $exe -p $pidfile $options $DIR $params $PORT $COMMAND >> $LOG 2>&1 < /dev/null
-    $CHROOT su $USER -c "$exe -p $pidfile $options $DIR $params $PORT $COMMAND >> $LOG 2>&1 < /dev/null"
+    $CHROOT su $USER -c "$exe -L$logdir/output_$PORT.log --logstamp='%F %T ' -p $pidfile $options $DIR $params $PORT $COMMAND >> $LOG 2>&1 < /dev/null"
     # check if starting worked or failed
     sleep 1
     if [ -e $pidfile ]


### PR DESCRIPTION
Redirect logging output (you can see with "telnet localhost 50000/01") to logging files. Since we are normally using overlayFS the size of the logfiles are limited with logrotate.